### PR TITLE
Use gir consistently as library name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ slog-term = "1.3.5"
 tera = "0.6.2"
 
 [lib]
-name = "graph_ir"
+name = "gir"
 path = "src/lib.rs"
 
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 #[macro_use]
-extern crate graph_ir;
+extern crate gir;
 extern crate slog_term;
 
-use graph_ir as gir;
 use gir::api::*;
 use std::fs::File;
 


### PR DESCRIPTION
Also solves the problem where the docs didn't build correctly.